### PR TITLE
Exercicio 2: Implementa `ValorReal` e operações aritméticas sobre os reais

### DIFF
--- a/Expressoes1/src/le1/plp/expressions1/expression/ExpMenos.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ExpMenos.java
@@ -27,7 +27,9 @@ public class ExpMenos extends ExpUnaria{
 	 *            o ambiente de execu��o.
 	 */
 	public Valor avaliar(AmbienteExecucao amb) {
-		return new ValorInteiro(- ((ValorInteiro)getExp().avaliar(amb)).valor());
+		TipoPrimitivo tipoExpr = getExp() instanceof ValorReal ? TipoPrimitivo.REAL : TipoPrimitivo.INTEIRO;
+
+		return new ValorNumerico(- ((ValorNumerico)getExp().avaliar(amb)).valor(), tipoExpr);
 	}
 
 	/**
@@ -40,7 +42,8 @@ public class ExpMenos extends ExpUnaria{
 	 *         <code>false</code> caso contrario.
 	 */
 	protected boolean checaTipoElementoTerminal(AmbienteCompilacao amb) {
-		return (getExp().getTipo(amb).eInteiro());
+		boolean numerico = getExp().getTipo(amb).eInteiro() || getExp().getTipo(amb).eReal();
+		return numerico;
 	}
 
 	/**
@@ -52,6 +55,6 @@ public class ExpMenos extends ExpUnaria{
 	 * @return os tipos possiveis desta expressao.
 	 */
 	public Tipo getTipo(AmbienteCompilacao amb) {
-		return TipoPrimitivo.INTEIRO;
+		return getExp().getTipo(amb);
 	}
 }

--- a/Expressoes1/src/le1/plp/expressions1/expression/ExpSoma.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ExpSoma.java
@@ -12,7 +12,7 @@ public class ExpSoma extends ExpBinaria {
 
 	/**
 	 * Controi uma Expressao de Soma com as sub-expressoes especificadas.
-	 * Assume-se que estas sub-expressoes resultam em <code>ValorInteiro</code> 
+	 * Assume-se que estas sub-expressoes resultam em <code>ValorNumerico</code> 
 	 * quando avaliadas.
 	 * @param esq Expressao da esquerda
 	 * @param dir Expressao da direita
@@ -28,9 +28,11 @@ public class ExpSoma extends ExpBinaria {
 	 *            o ambiente de execu��o.
 	 */
 	public Valor avaliar(AmbienteExecucao amb) {
-		return new ValorInteiro(
-			((ValorInteiro) getEsq().avaliar(amb)).valor() +
-			((ValorInteiro) getDir().avaliar(amb)).valor() );
+		TipoPrimitivo tipoExpr = getEsq() instanceof ValorReal ? TipoPrimitivo.REAL : TipoPrimitivo.INTEIRO;
+
+		return new ValorNumerico(
+			((ValorNumerico) getEsq().avaliar(amb)).valor() +
+			((ValorNumerico) getDir().avaliar(amb)).valor(), tipoExpr );
 	}
 	
 	/**
@@ -43,7 +45,11 @@ public class ExpSoma extends ExpBinaria {
 	 *         <code>false</code> caso contrario.
 	 */
 	protected boolean checaTipoElementoTerminal(AmbienteCompilacao amb) {
-		return (getEsq().getTipo(amb).eInteiro() && getDir().getTipo(amb).eInteiro());
+		boolean esqNumerico = getEsq().getTipo(amb).eInteiro() || getEsq().getTipo(amb).eReal();
+		boolean dirNumerico =  getDir().getTipo(amb).eInteiro() || getDir().getTipo(amb).eReal();
+		boolean esqDirIguais = getEsq().getTipo(amb).eIgual(getDir().getTipo(amb));
+
+		return esqNumerico && dirNumerico && esqDirIguais;
 	}
 
 	/**
@@ -55,7 +61,7 @@ public class ExpSoma extends ExpBinaria {
 	 * @return os tipos possiveis desta expressao.
 	 */
 	public Tipo getTipo(AmbienteCompilacao amb) {
-		return TipoPrimitivo.INTEIRO;
+		return getEsq().getTipo(amb);
 	}
 
 }

--- a/Expressoes1/src/le1/plp/expressions1/expression/ExpSomaReal.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ExpSomaReal.java
@@ -1,0 +1,61 @@
+package le1.plp.expressions1.expression;
+
+import le1.plp.expressions1.util.Tipo;
+import le1.plp.expressions1.util.TipoPrimitivo;
+import le1.plp.expressions2.memory.AmbienteCompilacao;
+import le1.plp.expressions2.memory.AmbienteExecucao;
+
+/**
+ * Um objeto desta classe representa uma Expressao de Soma.
+ */
+public class ExpSomaReal extends ExpBinaria {
+
+	/**
+	 * Controi uma Expressao de Soma com as sub-expressoes especificadas.
+	 * Assume-se que estas sub-expressoes resultam em <code>ValorReal</code> 
+	 * quando avaliadas.
+	 * @param esq Expressao da esquerda
+	 * @param dir Expressao da direita
+	 */
+	public ExpSomaReal(Expressao esq, Expressao dir) {
+		super(esq, dir, "+");
+	}
+
+	/**
+	 * Retorna o valor da Expressao de Soma
+	 * 
+	 * @param amb
+	 *            o ambiente de execu��o.
+	 */
+	public Valor avaliar(AmbienteExecucao amb) {
+		return new ValorReal(
+			((ValorReal) getEsq().avaliar(amb)).valor() +
+			((ValorReal) getDir().avaliar(amb)).valor() );
+	}
+	
+	/**
+	 * Realiza a verificacao de tipos desta expressao.
+	 *
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 *
+	 * @return <code>true</code> se os tipos da expressao sao validos;
+	 *         <code>false</code> caso contrario.
+	 */
+	protected boolean checaTipoElementoTerminal(AmbienteCompilacao amb) {
+		return (getEsq().getTipo(amb).eReal() && getDir().getTipo(amb).eReal());
+	}
+
+	/**
+	 * Retorna os tipos possiveis desta expressao.
+	 * 
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 * 
+	 * @return os tipos possiveis desta expressao.
+	 */
+	public Tipo getTipo(AmbienteCompilacao amb) {
+		return TipoPrimitivo.REAL;
+	}
+
+}

--- a/Expressoes1/src/le1/plp/expressions1/expression/ExpSub.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ExpSub.java
@@ -12,7 +12,7 @@ public class ExpSub extends ExpBinaria {
 
 	/**
 	 * Controi uma Expressao de Subtracao com as sub-expressoes especificadas.
-	 * Assume-se que estas expressoes resultam em <code>ValorInteiro</code>
+	 * Assume-se que estas expressoes resultam em <code>ValorNumerico</code>
 	 * quando avaliadas.
 	 *
 	 * @param esq Expressao da esquerda
@@ -29,9 +29,11 @@ public class ExpSub extends ExpBinaria {
 	 *            o ambiente de execu��o.
 	 */
 	public Valor avaliar(AmbienteExecucao amb) {
-		return new ValorInteiro(
-				((ValorInteiro)getEsq().avaliar(amb)).valor() -
-				((ValorInteiro)getDir().avaliar(amb)).valor()
+		TipoPrimitivo tipoExpr = getEsq() instanceof ValorReal ? TipoPrimitivo.REAL : TipoPrimitivo.INTEIRO;
+
+		return new ValorNumerico(
+				((ValorNumerico)getEsq().avaliar(amb)).valor() -
+				((ValorNumerico)getDir().avaliar(amb)).valor(), tipoExpr
 		);
 	}
 
@@ -45,7 +47,11 @@ public class ExpSub extends ExpBinaria {
 	 *         <code>false</code> caso contrario.
 	 */
 	protected boolean checaTipoElementoTerminal(AmbienteCompilacao amb) {
-		return (getEsq().getTipo(amb).eInteiro() && getDir().getTipo(amb).eInteiro());
+		boolean esqNumerico = getEsq().getTipo(amb).eInteiro() || getEsq().getTipo(amb).eReal();
+		boolean dirNumerico =  getDir().getTipo(amb).eInteiro() || getDir().getTipo(amb).eReal();
+		boolean esqDirIguais = getEsq().getTipo(amb).eIgual(getDir().getTipo(amb));
+
+		return esqNumerico && dirNumerico && esqDirIguais;
 	}
 
 	/**

--- a/Expressoes1/src/le1/plp/expressions1/expression/ValorInteiro.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ValorInteiro.java
@@ -1,28 +1,12 @@
 package le1.plp.expressions1.expression;
 
-import le1.plp.expressions1.util.Tipo;
 import le1.plp.expressions1.util.TipoPrimitivo;
-import le1.plp.expressions2.memory.AmbienteCompilacao;
 
 /**
  * Objetos desta classe encapsulam valor inteiro.
  */
-public class ValorInteiro extends ValorConcreto<Integer> {
-	
+public class ValorInteiro extends ValorNumerico {
 	public ValorInteiro(int valor) {
-		super(valor);
+		super(valor, TipoPrimitivo.INTEIRO);
 	}
-	
-	/**
-	 * Retorna os tipos possiveis desta expressao.
-	 * 
-	 * @param amb
-	 *            o ambiente de compila��o.
-	 * 
-	 * @return os tipos possiveis desta expressao.
-	 */
-	public Tipo getTipo(AmbienteCompilacao amb) {
-		return TipoPrimitivo.INTEIRO;
-	}
-
 }

--- a/Expressoes1/src/le1/plp/expressions1/expression/ValorNumerico.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ValorNumerico.java
@@ -5,14 +5,17 @@ import le1.plp.expressions1.util.TipoPrimitivo;
 import le1.plp.expressions2.memory.AmbienteCompilacao;
 
 /**
- * Este valor primitivo encapsula um String.
+ * Objetos desta classe encapsulam valores numericos (reais e inteiros)
  */
-public class ValorString extends ValorConcreto<String> {
+public class ValorNumerico extends ValorConcreto<Double> {
 
-	public ValorString(String valor) {
+    private Tipo tipo;
+	
+	public ValorNumerico(double valor, Tipo tipo) {
 		super(valor);
+        this.tipo = tipo;
 	}
-
+	
 	/**
 	 * Retorna os tipos possiveis desta expressao.
 	 * 
@@ -22,11 +25,15 @@ public class ValorString extends ValorConcreto<String> {
 	 * @return os tipos possiveis desta expressao.
 	 */
 	public Tipo getTipo(AmbienteCompilacao amb) {
-		return TipoPrimitivo.STRING;
+		return this.tipo;
 	}
 
-	@Override
+    @Override
 	public String toString() {
-		return String.format("xxx\"%s\"", super.toString());
+        if (this.tipo == TipoPrimitivo.INTEIRO) {
+		    return String.format("%d", (int) Math.round(this.valor()));
+        }
+
+        return String.format("%f", this.valor());
 	}
 }

--- a/Expressoes1/src/le1/plp/expressions1/expression/ValorReal.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ValorReal.java
@@ -1,28 +1,12 @@
 package le1.plp.expressions1.expression;
 
-import le1.plp.expressions1.util.Tipo;
 import le1.plp.expressions1.util.TipoPrimitivo;
-import le1.plp.expressions2.memory.AmbienteCompilacao;
 
 /**
- * Objetos desta classe encapsulam valor inteiro.
+ * Objetos desta classe encapsulam valor real.
  */
-public class ValorReal extends ValorConcreto<Float> {
-	
-	public ValorReal(float valor) {
-		super(valor);
+public class ValorReal extends ValorNumerico {
+	public ValorReal(double valor) {
+		super(valor, TipoPrimitivo.REAL);
 	}
-	
-	/**
-	 * Retorna os tipos possiveis desta expressao.
-	 * 
-	 * @param amb
-	 *            o ambiente de compila��o.
-	 * 
-	 * @return os tipos possiveis desta expressao.
-	 */
-	public Tipo getTipo(AmbienteCompilacao amb) {
-		return TipoPrimitivo.REAL;
-	}
-
 }

--- a/Expressoes1/src/le1/plp/expressions1/expression/ValorReal.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ValorReal.java
@@ -1,0 +1,28 @@
+package le1.plp.expressions1.expression;
+
+import le1.plp.expressions1.util.Tipo;
+import le1.plp.expressions1.util.TipoPrimitivo;
+import le1.plp.expressions2.memory.AmbienteCompilacao;
+
+/**
+ * Objetos desta classe encapsulam valor inteiro.
+ */
+public class ValorReal extends ValorConcreto<Float> {
+	
+	public ValorReal(float valor) {
+		super(valor);
+	}
+	
+	/**
+	 * Retorna os tipos possiveis desta expressao.
+	 * 
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 * 
+	 * @return os tipos possiveis desta expressao.
+	 */
+	public Tipo getTipo(AmbienteCompilacao amb) {
+		return TipoPrimitivo.REAL;
+	}
+
+}

--- a/Expressoes1/src/le1/plp/expressions1/parser/Expressoes1.jj
+++ b/Expressoes1/src/le1/plp/expressions1/parser/Expressoes1.jj
@@ -121,6 +121,7 @@ TOKEN : /* LITERALS */
 | < #DECIMAL_LITERAL : [ "1"-"9" ] ([ "0"-"9" ])* >
 | < #HEX_LITERAL : "0" [ "x", "X" ] ([ "0"-"9", "a"-"f", "A"-"F" ])+ >
 | < #OCTAL_LITERAL : "0" ([ "0"-"7" ])* >
+| < REAL_LITERAL : ((["0"-"9"])+(".")(["0"-"9"])+)>
 | < STRING_LITERAL :
     "\""
     (
@@ -211,6 +212,18 @@ Valor PValorInteiro() :
   }
 }
 
+Valor PValorReal() :
+{
+  Token token;
+}
+{
+  token = < REAL_LITERAL >
+  {
+    return new ValorReal(Float.parseFloat(token.toString()));
+  }
+}
+
+
 Valor PValorBooleano() :
 {}
 {
@@ -244,6 +257,7 @@ Valor PValor() :
 {
   (
     retorno = PValorInteiro()
+  | retorno = PValorReal()
   | retorno = PValorBooleano()
   | retorno = PValorString()
   )

--- a/Expressoes1/src/le1/plp/expressions1/parser/Expressoes1.jj
+++ b/Expressoes1/src/le1/plp/expressions1/parser/Expressoes1.jj
@@ -219,7 +219,7 @@ Valor PValorReal() :
 {
   token = < REAL_LITERAL >
   {
-    return new ValorReal(Float.parseFloat(token.toString()));
+    return new ValorReal(Double.parseDouble(token.toString()));
   }
 }
 

--- a/Expressoes1/src/le1/plp/expressions1/util/Tipo.java
+++ b/Expressoes1/src/le1/plp/expressions1/util/Tipo.java
@@ -21,6 +21,14 @@ public interface Tipo {
 	public abstract boolean eInteiro();
 
 	/**
+	 * Indica se esta expressao é real.
+	 * 
+	 * @return <code>true</code> se esta expressao for inteira;
+	 *         <code>false</code> caso contrario.
+	 */
+	public abstract boolean eReal();
+
+	/**
 	 * Indica se esta expressao &eacute; booleana.
 	 * 
 	 * @return <code>true</code> se esta expressao for booleana;

--- a/Expressoes1/src/le1/plp/expressions1/util/TipoPrimitivo.java
+++ b/Expressoes1/src/le1/plp/expressions1/util/TipoPrimitivo.java
@@ -10,6 +10,7 @@ package le1.plp.expressions1.util;
 public enum TipoPrimitivo implements Tipo {
 
 	INTEIRO("INTEIRO"),
+	REAL("REAL"),
 	BOOLEANO("BOOLEANO"),
 	STRING("STRING");
 
@@ -34,6 +35,13 @@ public enum TipoPrimitivo implements Tipo {
 	 */
 	public boolean eInteiro() {
 		return this.eIgual(INTEIRO);
+	}
+
+	/* (non-Javadoc)
+	 * @see le1.plp.expressions1.util.Tipo#eReal()
+	 */
+	public boolean eReal() {
+		return this.eIgual(REAL);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
Exercício 2
> Implementar ValorReal e as operações aritméticas usuais sobre os reais

- Dúvida: da forma como está feito, sempre realizamos operações sobre `double`. Haveria um jeito de diferenciar o tipo concreto e realizar a operação realmente sobre o tipo ao invés de sempre usar double?
  - Isso provavelmente decorre do fato de que o construtor de `ValorNumerico` usa tipo `double`. Deveríamos usar generic? 