### PR TITLE
Exercicio 3: implementa operadores relacionais para inteiros (maior que, menor que)

### DIFF
--- a/Expressoes1/src/le1/plp/expressions1/expression/ExpMaiorQue.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ExpMaiorQue.java
@@ -1,0 +1,61 @@
+package le1.plp.expressions1.expression;
+
+import le1.plp.expressions1.util.Tipo;
+import le1.plp.expressions1.util.TipoPrimitivo;
+import le1.plp.expressions2.memory.AmbienteCompilacao;
+import le1.plp.expressions2.memory.AmbienteExecucao;
+
+/**
+ * Um objeto desta classe representa uma Expressao de Soma.
+ */
+public class ExpMaiorQue extends ExpBinaria {
+
+	/**
+	 * Controi uma Expressao de Soma com as sub-expressoes especificadas.
+	 * Assume-se que estas sub-expressoes resultam em <code>ValorInteiro</code> 
+	 * quando avaliadas.
+	 * @param esq Expressao da esquerda
+	 * @param dir Expressao da direita
+	 */
+	public ExpMaiorQue(Expressao esq, Expressao dir) {
+		super(esq, dir, ">");
+	}
+
+	/**
+	 * Retorna o valor da Expressao de Soma
+	 * 
+	 * @param amb
+	 *            o ambiente de execu��o.
+	 */
+	public Valor avaliar(AmbienteExecucao amb) {
+		return new ValorBooleano(
+			((ValorInteiro) getEsq().avaliar(amb)).valor() >
+			((ValorInteiro) getDir().avaliar(amb)).valor() );
+	}
+	
+	/**
+	 * Realiza a verificacao de tipos desta expressao.
+	 *
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 *
+	 * @return <code>true</code> se os tipos da expressao sao validos;
+	 *         <code>false</code> caso contrario.
+	 */
+	protected boolean checaTipoElementoTerminal(AmbienteCompilacao amb) {
+		return (getEsq().getTipo(amb).eInteiro() && getDir().getTipo(amb).eInteiro());
+	}
+
+	/**
+	 * Retorna os tipos possiveis desta expressao.
+	 * 
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 * 
+	 * @return os tipos possiveis desta expressao.
+	 */
+	public Tipo getTipo(AmbienteCompilacao amb) {
+		return TipoPrimitivo.BOOLEANO;
+	}
+
+}

--- a/Expressoes1/src/le1/plp/expressions1/expression/ExpMenorQue.java
+++ b/Expressoes1/src/le1/plp/expressions1/expression/ExpMenorQue.java
@@ -1,0 +1,61 @@
+package le1.plp.expressions1.expression;
+
+import le1.plp.expressions1.util.Tipo;
+import le1.plp.expressions1.util.TipoPrimitivo;
+import le1.plp.expressions2.memory.AmbienteCompilacao;
+import le1.plp.expressions2.memory.AmbienteExecucao;
+
+/**
+ * Um objeto desta classe representa uma Expressao de Soma.
+ */
+public class ExpMenorQue extends ExpBinaria {
+
+	/**
+	 * Controi uma Expressao de Soma com as sub-expressoes especificadas.
+	 * Assume-se que estas sub-expressoes resultam em <code>ValorInteiro</code> 
+	 * quando avaliadas.
+	 * @param esq Expressao da esquerda
+	 * @param dir Expressao da direita
+	 */
+	public ExpMenorQue(Expressao esq, Expressao dir) {
+		super(esq, dir, "<");
+	}
+
+	/**
+	 * Retorna o valor da Expressao de Soma
+	 * 
+	 * @param amb
+	 *            o ambiente de execu��o.
+	 */
+	public Valor avaliar(AmbienteExecucao amb) {
+		return new ValorBooleano(
+			((ValorInteiro) getEsq().avaliar(amb)).valor() <
+			((ValorInteiro) getDir().avaliar(amb)).valor() );
+	}
+	
+	/**
+	 * Realiza a verificacao de tipos desta expressao.
+	 *
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 *
+	 * @return <code>true</code> se os tipos da expressao sao validos;
+	 *         <code>false</code> caso contrario.
+	 */
+	protected boolean checaTipoElementoTerminal(AmbienteCompilacao amb) {
+		return (getEsq().getTipo(amb).eInteiro() && getDir().getTipo(amb).eInteiro());
+	}
+
+	/**
+	 * Retorna os tipos possiveis desta expressao.
+	 * 
+	 * @param amb
+	 *            o ambiente de compila��o.
+	 * 
+	 * @return os tipos possiveis desta expressao.
+	 */
+	public Tipo getTipo(AmbienteCompilacao amb) {
+		return TipoPrimitivo.BOOLEANO;
+	}
+
+}

--- a/Expressoes1/src/le1/plp/expressions1/parser/Expressoes1.jj
+++ b/Expressoes1/src/le1/plp/expressions1/parser/Expressoes1.jj
@@ -354,6 +354,14 @@ Expressao PExpBinaria2() :
       {
         retorno = new ExpSub(retorno, param2);
       }
+    | < GT > param2 = PExpBinaria3()
+      {
+        retorno = new ExpMaiorQue(retorno, param2);
+      }
+    | < LT > param2 = PExpBinaria3()
+      {
+        retorno = new ExpMenorQue(retorno, param2);
+      }
     | < OR > param2 = PExpBinaria3()
       {
         retorno = new ExpOr(retorno, param2);


### PR DESCRIPTION
Exercício 3
> Implementar operadores relacionais como menor que, maior que, ..., para valores inteiros 

- OBS: Não implementado "maior ou igual" pois não seria nada além do que foi feito para maior que/menor que. Apenas copiar e colar a classe, poucas alterações, e então atualizar o parser.